### PR TITLE
fix:plots_utility changed to string to match matplotlib 3.3+

### DIFF
--- a/Python_code/plots_utility.py
+++ b/Python_code/plots_utility.py
@@ -24,7 +24,7 @@ from mpl_toolkits.axes_grid1.inset_locator import inset_axes
 rcParams['font.family'] = 'serif'
 rcParams['font.serif'] = 'Times'
 rcParams['text.usetex'] = 'true'
-rcParams['text.latex.preamble'] = [r'\usepackage{newtxmath}']
+rcParams['text.latex.preamble'] = r'\usepackage{newtxmath}'
 rcParams['font.size'] = 16
 
 


### PR DESCRIPTION
fixes #5 
there is a matplotlib version compatibility issue with the text.latex.preamble rcParam.
The key now expects a string in more recent matplotlib versions (3.3+), the key is provided an array instead.
 